### PR TITLE
fix: top_result was not correctly fetched

### DIFF
--- a/google_play_scraper/features/search.py
+++ b/google_play_scraper/features/search.py
@@ -38,7 +38,7 @@ def search(
             dataset[key] = value
 
     try:
-        top_result = dataset["ds:4"][0][1][0][23][16]
+        top_result = dataset["ds:4"][0][1][1][23][16]
     except IndexError:
         top_result = None
 


### PR DESCRIPTION
Now fetch array dataset["ds:4˝][0][1][1]... ] because item 0 now contains a disclaimer about the search results instead of the top result